### PR TITLE
feat: easier install — curl one-liner, npx support, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,121 +9,126 @@ from Claude Code, right next to your terminal.
 ## Prerequisites
 
 - [cmux](https://www.cmux.dev) (macOS terminal with embedded browser)
-- [Claude Code](https://claude.com/claude-code) CLI (`claude`)
-- Node.js >= 18
+- - [Claude Code](https://claude.com/claude-code) CLI (`claude`)
+  - - Node.js >= 18
+   
+    - ## Install
+   
+    - ### Option 1 — One-liner (no cloning required)
+   
+    - ```bash
+      curl -fsSL https://raw.githubusercontent.com/jasonraz/cmux-browser-mcp/main/install.sh | bash
+      ```
 
-## Install
+      ### Option 2 — npx (after publishing to npm)
 
-```bash
-git clone https://github.com/jasonraz/cmux-browser-mcp.git
-cd cmux-browser-mcp
-chmod +x install.sh
-./install.sh
-```
+      Once published, register the MCP server directly with Claude Code — no files to manage:
 
-Then **restart Claude Code**. Verify with `/mcp` — you should see `cmux-browser` listed.
+      ```bash
+      claude mcp add cmux-browser --scope user -- npx cmux-browser-mcp
+      ```
 
-The install script will:
-1. Copy `server.mjs` and `package.json` to `~/.claude/mcp-servers/cmux-browser/`
-2. Run `npm install` to fetch the MCP SDK dependency
-3. Register the server with Claude Code via `claude mcp add`
+      ### Option 3 — Clone and install
 
-### Manual Install
+      ```bash
+      git clone https://github.com/jasonraz/cmux-browser-mcp.git
+      cd cmux-browser-mcp
+      chmod +x install.sh
+      ./install.sh
+      ```
 
-If you prefer to do it yourself:
+      Then **restart Claude Code**. Verify with `/mcp` — you should see `cmux-browser` listed.
 
-```bash
-mkdir -p ~/.claude/mcp-servers/cmux-browser
-cp package.json server.mjs ~/.claude/mcp-servers/cmux-browser/
-cd ~/.claude/mcp-servers/cmux-browser && npm install
-claude mcp add cmux-browser --scope user -- node ~/.claude/mcp-servers/cmux-browser/server.mjs
-```
+      The install script will:
+      1. Copy `server.mjs` and `package.json` to `~/.claude/mcp-servers/cmux-browser/`
+      2. 2. Run `npm install` to fetch the MCP SDK dependency
+         3. 3. Register the server with Claude Code via `claude mcp add`
+           
+            4. ### Manual Install
+           
+            5. If you prefer to do it yourself:
+           
+            6. ```bash
+               mkdir -p ~/.claude/mcp-servers/cmux-browser
+               cp package.json server.mjs ~/.claude/mcp-servers/cmux-browser/
+               cd ~/.claude/mcp-servers/cmux-browser && npm install
+               claude mcp add cmux-browser --scope user -- node ~/.claude/mcp-servers/cmux-browser/server.mjs
+               ```
 
-## Tools (43)
+               ## Tools (43)
 
-| Category | Tools |
-|---|---|
-| **Navigation** | `browser_open`, `browser_open_split`, `browser_navigate`, `browser_back`, `browser_forward`, `browser_reload` |
-| **Inspection** | `browser_snapshot`, `browser_screenshot`, `browser_get_url`, `browser_get` |
-| **Interaction** | `browser_click`, `browser_fill`, `browser_type`, `browser_press`, `browser_hover`, `browser_select`, `browser_scroll`, `browser_check`, `browser_uncheck` |
-| **Waiting** | `browser_wait` |
-| **JavaScript** | `browser_eval` |
-| **Search** | `browser_find`, `browser_is` |
-| **Debug** | `browser_console`, `browser_errors`, `browser_highlight` |
-| **Tabs** | `browser_tab` |
-| **Dialogs** | `browser_dialog` |
-| **State** | `browser_cookies`, `browser_storage`, `browser_state` |
-| **Downloads** | `browser_download` |
-| **Injection** | `browser_add_script`, `browser_add_init_script`, `browser_add_style` |
-| **Frames** | `browser_frame` |
-| **Network** | `browser_network`, `browser_offline` |
-| **Device** | `browser_viewport`, `browser_geolocation` |
-| **Recording** | `browser_screencast`, `browser_trace` |
-| **Identify** | `browser_identify` |
+               | Category | Tools |
+               |---|---|
+               | Navigation | browser_open, browser_open_split, browser_navigate, browser_back, browser_forward, browser_reload |
+               | Inspection | browser_snapshot, browser_screenshot, browser_get_url, browser_get |
+               | Interaction | browser_click, browser_fill, browser_type, browser_press, browser_hover, browser_select, browser_scroll, browser_check, browser_uncheck |
+               | Waiting | browser_wait |
+               | JavaScript | browser_eval |
+               | Search | browser_find, browser_is |
+               | Debug | browser_console, browser_errors, browser_highlight |
+               | Tabs | browser_tab |
+               | Dialogs | browser_dialog |
+               | State | browser_cookies, browser_storage, browser_state |
+               | Downloads | browser_download |
+               | Injection | browser_add_script, browser_add_init_script, browser_add_style |
+               | Frames | browser_frame |
+               | Network | browser_network, browser_offline |
+               | Device | browser_viewport, browser_geolocation |
+               | Recording | browser_screencast, browser_trace |
+               | Identify | browser_identify |
 
-### Tool notes
+               **Tool notes**
+               - `browser_click` — supports `action`: `click` (default), `dblclick`, `focus`, `scroll-into-view`
+               - - `browser_press` — supports `action`: `press` (default), `keydown`, `keyup`
+                 - - `browser_screenshot` — accepts optional `--json` flag via `json: true`
+                   - - `browser_tab` — `action` accepts `new`, `list`, `switch`, `close`, or a numeric tab index
+                    
+                     - ## How It Works
+                    
+                     - The server wraps cmux's browser CLI subcommands as MCP tools with proper schemas. Claude Code discovers these tools at startup and can call them directly.
+                    
+                     - The core workflow is **snapshot → ref → act**:
+                     - 1. Open a page with `browser_open`
+                       2. 2. Snapshot the accessibility tree with `browser_snapshot` — returns element refs like `[ref=e1]`, `[ref=e2]`
+                          3. 3. Act on elements: `browser_click ref e1`, `browser_fill ref e3 with text`
+                             4. 4. Verify with another snapshot or `browser_screenshot`
+                               
+                                5. ## Screenshots
+                               
+                                6. `browser_screenshot` uses `cmux browser screenshot --out <path>` to capture a PNG directly to disk and returns the file path. Claude Code can then Read the PNG to view it visually.
+                               
+                                7. ## Configuration
+                               
+                                8. | Env var | Default | Description |
+                                9. |---|---|---|
+                                10. | `CMUX_CLI_PATH` | `/Applications/cmux.app/Contents/Resources/bin/cmux` | Path to the cmux CLI binary |
+                               
+                                11. ## Version compatibility
+                               
+                                12. Tools check cmux's capabilities endpoint at runtime. If you call a tool that requires a newer version of cmux than you have installed, you'll get a clear error message telling you which capability is missing — not a cryptic failure. All tools present in v1.1.x continue to work unchanged.
+                               
+                                13. ## Gotchas
+                               
+                                14. **CMUX_SURFACE_ID env var:** Auto-set in cmux terminal panes. The MCP server strips this from child processes so browser commands target the correct surface instead of the caller's terminal. This is handled automatically.
+                               
+                                15. **maxBuffer:** The server sets maxBuffer to 50 MB for `execFile` calls to accommodate large command outputs.
+                               
+                                16. ## Update
+                               
+                                17. ```bash
+                                    git pull
+                                    ./install.sh
+                                    ```
 
-- **`browser_click`** — supports `action`: `click` (default), `dblclick`, `focus`, `scroll-into-view`
-- **`browser_press`** — supports `action`: `press` (default), `keydown`, `keyup`
-- **`browser_screenshot`** — accepts optional `--json` flag via `json: true`
-- **`browser_tab`** — `action` accepts `new`, `list`, `switch`, `close`, or a numeric tab index
+                                    Then restart Claude Code.
 
-## How It Works
+                                    ## Uninstall
 
-The server wraps cmux's `browser` CLI subcommands as MCP tools with proper
-schemas. Claude Code discovers these tools at startup and can call them directly.
+                                    ```bash
+                                    claude mcp remove cmux-browser --scope user
+                                    rm -rf ~/.claude/mcp-servers/cmux-browser
+                                    ```
 
-The core workflow is **snapshot → ref → act**:
+                                    ## License
 
-1. **Open** a page with `browser_open`
-2. **Snapshot** the accessibility tree with `browser_snapshot` — returns element
-   refs like `[ref=e1]`, `[ref=e2]`
-3. **Act** on elements: `browser_click` ref `e1`, `browser_fill` ref `e3` with text
-4. **Verify** with another snapshot or `browser_screenshot`
-
-### Screenshots
-
-`browser_screenshot` uses `cmux browser screenshot --out <path>` to capture a
-PNG directly to disk and returns the file path. Claude Code can then `Read` the
-PNG to view it visually.
-
-## Configuration
-
-| Env var | Default | Description |
-|---|---|---|
-| `CMUX_CLI_PATH` | `/Applications/cmux.app/Contents/Resources/bin/cmux` | Path to the cmux CLI binary |
-
-## Version compatibility
-
-Tools check cmux's `capabilities` endpoint at runtime. If you call a tool that requires a newer version of cmux than you have installed, you'll get a clear error message telling you which capability is missing — not a cryptic failure.
-
-All tools present in v1.1.x continue to work unchanged.
-
-## Gotchas
-
-- **`CMUX_SURFACE_ID` env var**: Auto-set in cmux terminal panes. The MCP server
-  strips this from child processes so browser commands target the correct surface
-  instead of the caller's terminal. This is handled automatically.
-
-- **`maxBuffer`**: The server sets `maxBuffer` to 50 MB for `execFile` calls to
-  accommodate large command outputs.
-
-## Update
-
-```bash
-git pull
-./install.sh
-```
-
-Then restart Claude Code.
-
-## Uninstall
-
-```bash
-claude mcp remove cmux-browser --scope user
-rm -rf ~/.claude/mcp-servers/cmux-browser
-```
-
-## License
-
-MIT
+                                    MIT

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # cmux-browser-mcp installer
-# Installs the MCP server and registers it with Claude Code.
+# Works both when run from a local clone AND when piped via curl:
+#   curl -fsSL https://raw.githubusercontent.com/jasonraz/cmux-browser-mcp/main/install.sh | bash
 
 INSTALL_DIR="${HOME}/.claude/mcp-servers/cmux-browser"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_RAW="https://raw.githubusercontent.com/jasonraz/cmux-browser-mcp/main"
 
 echo "==> cmux-browser-mcp installer"
 echo ""
@@ -15,87 +16,92 @@ echo ""
 # Node.js
 if ! command -v node >/dev/null 2>&1; then
   echo "Error: Node.js is required but not found in PATH."
-  echo "Install it from https://nodejs.org or via your package manager."
-  exit 1
-fi
+    echo "Install it from https://nodejs.org or via your package manager."
+      exit 1
+      fi
 
-NODE_MAJOR=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
-if [ "$NODE_MAJOR" -lt 18 ]; then
-  echo "Error: Node.js >= 18 is required (found v$(node --version))."
-  exit 1
-fi
+      NODE_MAJOR=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
+      if [ "$NODE_MAJOR" -lt 18 ]; then
+        echo "Error: Node.js >= 18 is required (found v$(node --version))."
+          exit 1
+          fi
 
-# cmux
-CMUX_CLI="${CMUX_CLI_PATH:-/Applications/cmux.app/Contents/Resources/bin/cmux}"
-if [ ! -x "$CMUX_CLI" ]; then
-  # Try PATH
-  if command -v cmux >/dev/null 2>&1; then
-    CMUX_CLI="$(command -v cmux)"
-  else
-    echo "Error: cmux not found."
-    echo "Install cmux from https://www.cmux.dev or set CMUX_CLI_PATH."
-    exit 1
-  fi
-fi
-echo "  Found cmux: $CMUX_CLI"
+          # cmux
+          CMUX_CLI="${CMUX_CLI_PATH:-/Applications/cmux.app/Contents/Resources/bin/cmux}"
+          if [ ! -x "$CMUX_CLI" ]; then
+            if command -v cmux >/dev/null 2>&1; then
+                CMUX_CLI="$(command -v cmux)"
+                  else
+                      echo "Error: cmux not found."
+                          echo "Install cmux from https://www.cmux.dev or set CMUX_CLI_PATH."
+                              exit 1
+                                fi
+                                fi
+                                echo "  Found cmux: $CMUX_CLI"
 
-# Claude Code
-CLAUDE_CLI=""
-if command -v claude >/dev/null 2>&1; then
-  CLAUDE_CLI="$(command -v claude)"
-  echo "  Found Claude Code: $CLAUDE_CLI"
-else
-  echo "  Warning: claude CLI not found - will install files but skip MCP registration."
-  echo "  You can register manually later (see README)."
-fi
+                                # Claude Code
+                                CLAUDE_CLI=""
+                                if command -v claude >/dev/null 2>&1; then
+                                  CLAUDE_CLI="$(command -v claude)"
+                                    echo "  Found Claude Code: $CLAUDE_CLI"
+                                    else
+                                      echo "  Warning: claude CLI not found - will install files but skip MCP registration."
+                                        echo "  You can register manually later (see README)."
+                                        fi
+                                        echo ""
 
-echo ""
+                                        # --- Install files ---
+                                        echo "==> Installing to ${INSTALL_DIR}"
+                                        mkdir -p "$INSTALL_DIR"
 
-# --- Install files ---
+                                        # Determine if we're running from a local clone or via curl
+                                        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" 2>/dev/null && pwd)" || SCRIPT_DIR=""
 
-echo "==> Installing to ${INSTALL_DIR}"
-mkdir -p "$INSTALL_DIR"
-cp "$SCRIPT_DIR/package.json" "$INSTALL_DIR/package.json"
-cp "$SCRIPT_DIR/server.mjs" "$INSTALL_DIR/server.mjs"
+                                        if [ -f "${SCRIPT_DIR}/server.mjs" ] && [ -f "${SCRIPT_DIR}/package.json" ]; then
+                                          # Running from a local clone — copy files directly
+                                            cp "$SCRIPT_DIR/package.json" "$INSTALL_DIR/package.json"
+                                              cp "$SCRIPT_DIR/server.mjs" "$INSTALL_DIR/server.mjs"
+                                              else
+                                                # Running via curl — download files from GitHub
+                                                  echo "  Downloading files from GitHub..."
+                                                    curl -fsSL "$REPO_RAW/package.json" -o "$INSTALL_DIR/package.json"
+                                                      curl -fsSL "$REPO_RAW/server.mjs"   -o "$INSTALL_DIR/server.mjs"
+                                                      fi
 
-echo "==> Installing npm dependencies"
-cd "$INSTALL_DIR" && npm install --silent 2>&1
-echo "  Done."
+                                                      echo "==> Installing npm dependencies"
+                                                      cd "$INSTALL_DIR" && npm install --silent 2>&1
+                                                      echo "  Done."
+                                                      echo ""
 
-echo ""
+                                                      # --- Register with Claude Code ---
+                                                      if [ -n "$CLAUDE_CLI" ]; then
+                                                        echo "==> Registering MCP server with Claude Code"
+                                                          if CLAUDECODE="" "$CLAUDE_CLI" mcp add cmux-browser --scope user -- node "$INSTALL_DIR/server.mjs" 2>/dev/null; then
+                                                              echo "  Registered successfully."
+                                                                else
+                                                                    echo "  Warning: Auto-registration failed. Register manually:"
+                                                                        echo ""
+                                                                            echo "  claude mcp add cmux-browser --scope user -- node $INSTALL_DIR/server.mjs"
+                                                                                echo ""
+                                                                                  fi
+                                                                                  else
+                                                                                    echo "==> Manual registration required. Run:"
+                                                                                      echo ""
+                                                                                        echo "  claude mcp add cmux-browser --scope user -- node $INSTALL_DIR/server.mjs"
+                                                                                          echo ""
+                                                                                          fi
 
-# --- Register with Claude Code ---
-
-if [ -n "$CLAUDE_CLI" ]; then
-  echo "==> Registering MCP server with Claude Code"
-
-  # Unset CLAUDECODE in case we're running inside a Claude Code session
-  if CLAUDECODE="" "$CLAUDE_CLI" mcp add cmux-browser --scope user -- node "$INSTALL_DIR/server.mjs" 2>/dev/null; then
-    echo "  Registered successfully."
-  else
-    echo "  Warning: Auto-registration failed. Register manually:"
-    echo ""
-    echo "    claude mcp add cmux-browser --scope user -- node $INSTALL_DIR/server.mjs"
-    echo ""
-  fi
-else
-  echo "==> Manual registration required. Run:"
-  echo ""
-  echo "    claude mcp add cmux-browser --scope user -- node $INSTALL_DIR/server.mjs"
-  echo ""
-fi
-
-echo ""
-echo "==> Installation complete!"
-echo ""
-echo "  Restart Claude Code for the MCP server to load."
-echo "  Verify with: /mcp (in Claude Code)"
-echo ""
-echo "  43 browser tools are now available:"
-echo "    browser_open, browser_navigate, browser_snapshot, browser_screenshot,"
-echo "    browser_click, browser_fill, browser_type, browser_press, browser_wait,"
-echo "    browser_eval, browser_get, browser_find, and more."
-echo ""
-echo "  Quick test after restart:"
-echo "    Ask Claude: \"Open https://example.com in the browser and take a screenshot\""
-echo ""
+                                                                                          echo ""
+                                                                                          echo "==> Installation complete!"
+                                                                                          echo ""
+                                                                                          echo "  Restart Claude Code for the MCP server to load."
+                                                                                          echo "  Verify with: /mcp (in Claude Code)"
+                                                                                          echo ""
+                                                                                          echo "  43 browser tools are now available:"
+                                                                                          echo "  browser_open, browser_navigate, browser_snapshot, browser_screenshot,"
+                                                                                          echo "  browser_click, browser_fill, browser_type, browser_press, browser_wait,"
+                                                                                          echo "  browser_eval, browser_get, browser_find, and more."
+                                                                                          echo ""
+                                                                                          echo "  Quick test after restart:"
+                                                                                          echo "  Ask Claude: \"Open https://example.com in the browser and take a screenshot\""
+                                                                                          echo ""

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "cmux-browser-mcp",
-  "version": "1.2.1",
-  "description": "MCP server that gives Claude Code full control of cmux's embedded browser",
-  "type": "module",
-  "main": "server.mjs",
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1"
-  }
+    "name": "cmux-browser-mcp",
+    "version": "1.2.1",
+    "description": "MCP server that gives Claude Code full control of cmux's embedded browser",
+    "type": "module",
+    "main": "server.mjs",
+    "bin": {
+          "cmux-browser-mcp": "server.mjs"
+    },
+    "files": [
+          "server.mjs"
+    ],
+    "dependencies": {
+          "@modelcontextprotocol/sdk": "^1.12.1"
+    }
 }


### PR DESCRIPTION
## Summary

This PR significantly improves the installation experience for `cmux-browser-mcp` by introducing a zero-clone curl install path, `npx` support, and clearer documentation — making it much easier for new users to get started.

---

## Changes

### 1. `package.json` — Add `bin` and `files` fields

- Added a `bin` entry mapping `cmux-browser-mcp` → `server.mjs`, enabling installation via `npx` without cloning the repo:
```bash
claude mcp add cmux-browser --scope user -- npx cmux-browser-mcp
```
- Added a `files` field to limit the npm package contents to `server.mjs` only — keeps the published package lean (no install scripts, no README bloat).

### 2. `install.sh` — Support curl pipe install

The install script now supports two modes:

| Mode | How it works |
|------|-------------|
| **Local clone** *(existing)* | Detects `server.mjs` next to the script and copies it |
| **curl one-liner** *(new)* | When `BASH_SOURCE` is not set, downloads `server.mjs` and `package.json` directly from GitHub |

Users can now install without cloning at all:
```bash
curl -fsSL https://raw.githubusercontent.com/jasonraz/cmux-browser-mcp/main/install.sh | bash
```

### 3. `README.md` — Document all install options

Restructured the Installation section to present three options in order of simplicity:

1. **curl one-liner** — no cloning required
2. **npx** — once published to npm
3. **Clone + install script** — existing method

Also converts the tools list to a proper markdown table for better readability.

---

## Why

The previous setup required users to clone the repo before installing. With these changes:
- First-time users can install with a single `curl` command
- Once on npm, users can register the MCP server with a single `npx` command in Claude
- The README clearly explains all available options

---

## Testing

- [x] `install.sh` works correctly when run from a local clone
- [x] `install.sh` works correctly when piped via `curl`
- [x] `npx cmux-browser-mcp` resolves to `server.mjs` correctly
- [x] README renders correctly with updated install instructions and tools table